### PR TITLE
filter on :mvn manifest when getting dep jars to fix #9

### DIFF
--- a/src/cambada/cli.clj
+++ b/src/cambada/cli.clj
@@ -67,10 +67,11 @@
       (not= deps (last config-files)) (conj deps))))
 
 (defn ^:private cli-options->deps-map
-  [{:keys [deps merge-config]}]
-  (if merge-config
-    (deps.reader/read-deps (config-files deps))
-    (-> deps io/file deps.reader/slurp-deps)))
+  [{:keys [deps merge-config] :as opts}]
+  (let [all-files (config-files deps)]
+    (if merge-config
+      (deps.reader/read-deps all-files)
+      (-> deps io/file deps.reader/slurp-deps))))
 
 (defn ^:private parsed-opts->task
   [{{:keys [deps main aot] :as options} :options

--- a/src/cambada/fs.clj
+++ b/src/cambada/fs.clj
@@ -1,0 +1,110 @@
+(ns cambada.fs
+  (:import [java.io File RandomAccessFile]
+           [java.nio.file.attribute BasicFileAttributes FileAttribute]
+           [java.nio ByteBuffer]
+           [java.nio.charset StandardCharsets]
+           [java.nio.channels FileChannel]
+           [java.nio.file FileSystem FileSystems FileVisitOption Files Path Paths
+            CopyOption LinkOption StandardCopyOption OpenOption StandardOpenOption]
+           [java.util.function BiPredicate]))
+
+
+
+
+(def kw->open-option
+  {:append StandardOpenOption/APPEND
+   :create StandardOpenOption/CREATE
+   :create-new StandardOpenOption/CREATE_NEW
+   :delete-on-close StandardOpenOption/DELETE_ON_CLOSE
+   :dsync StandardOpenOption/DSYNC
+   :read StandardOpenOption/READ
+   :sparse StandardOpenOption/SPARSE
+   :sync StandardOpenOption/SYNC
+   :truncate-existing StandardOpenOption/TRUNCATE_EXISTING
+   :write StandardOpenOption/WRITE})
+
+
+
+(defn normalize-open-options
+  "returns a set of StandardOpenOption from an input of
+   opts which contains keywords"
+  [opts]
+  (set (map kw->open-option opts)))
+
+(defn ^FileSystem default-fs
+  []
+  (FileSystems/getDefault))
+
+(defprotocol IPath
+  (path [this]))
+
+(extend-protocol IPath
+  String
+  (path [this]
+    (path (-> (default-fs) (.getPath this (make-array String 0)))))
+
+  File
+  (path [this]
+    (path (.getPath this)))
+
+  Path
+  (path [this] this))
+
+
+(defn directory?
+  "path is an instance of java.nio.file.Path"
+  [path & link-opts]
+  (Files/isDirectory path (into-array LinkOption link-opts)))
+
+(defn exists?
+  [path-like & link-opts]
+  (Files/exists (path path-like) (into-array LinkOption link-opts)))
+
+
+(def overwrite   "Overwrite file option"   ::overwrite)
+(def atomic-move "Atomic Move file option" ::atomic-move)
+(def copy-attrs  "Copy file attrs"         ::copy-attrs)
+
+(defn ^:private bi-predicate
+  [f]
+  (reify BiPredicate
+    (test [this t u] (f t u))))
+
+(defn relative-path
+  "Given parent path of `/usr/local/lib` and child of
+  `/usr/local/lib/clojure/deps.edn`returns a path that
+  is `clojure/deps.edn`"
+  ^Path [^Path parent ^Path child]
+  (.relativize parent child))
+
+(defn find-files
+  "root-path is something that can be converted to a path. Can be a String.
+   Returns nil or a seq of paths. nil is returned if the root-path doesn't
+   represent a valid path"
+  [root-path bi-pred]
+  (let [root-path (path root-path)]
+    (when (exists? root-path)
+      (->> (Files/find
+            root-path
+            Integer/MAX_VALUE
+            (bi-predicate bi-pred)
+            (into-array FileVisitOption []))
+           .iterator
+           iterator-seq))))
+
+(defn find-non-source-files
+  [root-path]
+  (let [pattern (re-pattern #".+(clj|cljs|cljc)$")]
+    (find-files
+     root-path
+     (fn [^Path path ^BasicFileAttributes file-attrs]
+       (and (.isRegularFile file-attrs)
+            (->> path .getFileName str (re-find pattern) nil?))))))
+
+
+(defn input-stream
+  "open-opts are keywords"
+  [file-path & open-opts]
+  (Files/newInputStream
+   (path file-path)
+   (into-array (normalize-open-options open-opts))))

--- a/src/cambada/jar.clj
+++ b/src/cambada/jar.clj
@@ -92,6 +92,19 @@
        ByteArrayInputStream.
        Manifest.))
 
+
+(defn make-project-properties
+  [{:keys [app-group-id app-artifact-id app-version] :as task}]
+  (with-open [baos (java.io.ByteArrayOutputStream.)]
+    (let [properties (doto (java.util.Properties.)
+                       (.setProperty "version" app-version)
+                       (.setProperty "groupId" app-group-id)
+                       (.setProperty "artifactId" app-artifact-id))]
+      (when-let [revision (utils/read-git-head)]
+        (.setProperty properties "revision" revision))
+      (.store properties baos "Cambada"))
+    (str baos)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Jar proper functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -194,6 +207,12 @@
     (first (filter #(instance? Element %) (first roots)))))
 
 
+(defn- write-pom-properties [{:keys [app-group-id app-artifact-id] :as task} jar-os jar-paths]
+  (let [path (format "META-INF/maven/%s/%s/pom.properties" app-group-id app-artifact-id)
+        props (make-project-properties task)]
+    (copy-to-jar task jar-os jar-paths {:type :bytes :bytes props :path path})))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -207,6 +226,7 @@
     (let [jar-paths (reduce (partial copy-to-jar task jar-os)
                             #{}
                             filespecs)]
+      (write-pom-properties task jar-os jar-paths)
       (if main
         (let [main-path (str (-> (string/replace main "." "/")
                                  (string/replace "-" "_"))

--- a/src/cambada/jar.clj
+++ b/src/cambada/jar.clj
@@ -221,8 +221,8 @@
 
 (defn ^:private sync-pom
   [{:keys [deps-map] :as task}]
-  (cli/info "Updating pom.xml") 
-  (gen.pom/sync-pom deps-map (io/file ".")) 
+  (cli/info "Updating pom.xml")
+  (gen.pom/sync-pom deps-map (io/file "."))
   (let [pom-file (io/file "." "pom.xml")
         pom (with-open [rdr (io/reader pom-file)]
               (-> rdr

--- a/src/cambada/uberjar.clj
+++ b/src/cambada/uberjar.clj
@@ -107,6 +107,8 @@
 (defn ^:private get-dep-jars
   [{:keys [deps-map]}]
   (->> (tools.deps/resolve-deps deps-map nil)
+       (filter (fn [[_ {:keys [deps/manifest]}]]
+                 (= :mvn manifest)))
        (map (fn [[_ {:keys [paths]}]] paths))
        (mapcat identity)))
 

--- a/src/cambada/uberjar.clj
+++ b/src/cambada/uberjar.clj
@@ -68,7 +68,7 @@
   (into (map-vals {}
                   (comp make-merger eval))
         (map #(vector % skip-merger)
-             [])))
+             (:uberjar-exclusions project))))
 
 (defn ^:private select-merger [mergers filename]
   (or (->> mergers (filter #(merger-match? % filename)) first second)
@@ -140,7 +140,8 @@
       (write-components task jars out))))
 
 (defn -main [& args]
-  (let [{:keys [help] :as task} (cli/args->task args cli-options)]
+  (let [{:keys [help] :as task} (-> (cli/args->task args cli-options)
+                                    (assoc :uberjar-exclusions [#"(?i)^META-INF/[^/]*\.(SF|RSA|DSA)$"]))]
     (cli/runner
      {:help? help
       :task task

--- a/src/cambada/utils.clj
+++ b/src/cambada/utils.clj
@@ -109,3 +109,15 @@
 (defn compiled-classes-path
   [out-path]
   (str out-path "/classes"))
+
+(defn group-by+
+  "Similar to group by, but allows applying val-fn to each item in the grouped by list of each key.
+   Can also apply val-agg-fn to the result of mapping val-fn. All input fns are 1 arity.
+   If val-fn and val-agg-fn were the identity fn then this behaves the same as group-by."
+  ([key-fn val-fn xs]
+   (group-by+ key-fn val-fn identity xs))
+  ([key-fn val-fn val-agg-fn xs]
+   (reduce (fn [m [k v]]
+             (assoc m k (val-agg-fn (map val-fn v))))
+           {}
+           (group-by key-fn xs))))

--- a/src/cambada/utils.clj
+++ b/src/cambada/utils.clj
@@ -1,5 +1,6 @@
 (ns cambada.utils
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :as sh])
   (:import (java.io File)))
 
 ;; # OS detection
@@ -121,3 +122,14 @@
              (assoc m k (val-agg-fn (map val-fn v))))
            {}
            (group-by key-fn xs))))
+
+
+(defn read-git-head
+  "Reads the value of HEAD and returns a commit SHA1, or nil if no commit
+  exist."
+  []
+  (try
+    (let [git-ref (sh/sh "git" "rev-parse" "HEAD")]
+      (when (= (:exit git-ref) 0)
+        (.trim (:out git-ref))))
+    (catch java.io.IOException e)))


### PR DESCRIPTION
This makes sure that only paths to jar files are returned by `get-dep-jars`.  This addresses issue #9.