### PR TITLE
uberjar-exclusions to fix #11

### DIFF
--- a/src/cambada/uberjar.clj
+++ b/src/cambada/uberjar.clj
@@ -68,7 +68,7 @@
   (into (map-vals {}
                   (comp make-merger eval))
         (map #(vector % skip-merger)
-             [])))
+             (:uberjar-exclusions project))))
 
 (defn ^:private select-merger [mergers filename]
   (or (->> mergers (filter #(merger-match? % filename)) first second)
@@ -138,7 +138,8 @@
       (write-components task jars out))))
 
 (defn -main [& args]
-  (let [{:keys [help] :as task} (cli/args->task args cli-options)]
+  (let [{:keys [help] :as task} (-> (cli/args->task args cli-options)
+                                    (assoc :uberjar-exclusions [#"(?i)^META-INF/[^/]*\.(SF|RSA|DSA)$"]))]
     (cli/runner
      {:help? help
       :task task


### PR DESCRIPTION
This is to fix #11.  

This mimics what `lein` does by default which is to exclude other jars signatures from inclusion in the uberjar.  This is necessary if a project ends up including something like Bouncy Castle in its deps.

NB. In `lein` `:uberjar-exclusions` is a configurable part of the project map. Here it is hard coded, but should help mitigate transitions for most projects in the immediate future.