### PR TITLE
Run compile in separate thread with empty classloader

### DIFF
--- a/src/cambada/compile.clj
+++ b/src/cambada/compile.clj
@@ -1,11 +1,17 @@
 (ns cambada.compile
   (:gen-class)
+  (:refer-clojure :exclude [compile])
   (:require [cambada.clean :as clean]
             [cambada.cli :as cli]
             [cambada.utils :as utils]
+            [cambada.compile.core :as compile]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [clojure.tools.namespace.find :as ns.find]))
+            [clojure.tools.namespace.find :as ns.find])
+  (:import [java.nio.file Path Paths Files]
+           [java.nio.file.attribute FileAttribute]
+           [java.io File]
+           [java.net URL URI URLClassLoader]))
 
 (def cli-options
   (concat [["-a" "--aot NS_NAMES" "Namespaces to be AOT-compiled or `all` (default)"
@@ -31,10 +37,28 @@
         aot-ns (aot-namespaces task)]
     (utils/mkdirs target)
     (cli/info "Creating" target)
-    (binding [*compile-path* target]
-      (doseq [ns aot-ns]
-        (cli/info "  Compiling" ns)
-        (compile ns)))))
+    (let [options *compiler-options*
+          classpath (System/getProperty "java.class.path")
+          classpath-urls (->> classpath compile/classpath->paths compile/paths->urls (into-array URL))
+          classloader (URLClassLoader. classpath-urls
+                                       (.getParent (ClassLoader/getSystemClassLoader)))
+          main-class (.loadClass classloader "clojure.main")
+          main-method (.getMethod
+                       main-class "main"
+                       (into-array Class [(Class/forName "[Ljava.lang.String;")]))
+          t (Thread. (fn []
+                       (.setContextClassLoader (Thread/currentThread) classloader)
+                       (.invoke
+                        main-method
+                        nil
+                        (into-array
+                         Object [(into-array String ["--main"
+                                                     "cambada.compile.core"
+                                                     (pr-str aot-ns)
+                                                     (pr-str options)])]))))]
+      (.start t)
+      (.join t)
+      (.close classloader))))
 
 (defn -main [& args]
   (let [{:keys [help] :as task} (cli/args->task args cli-options)]

--- a/src/cambada/compile/core.clj
+++ b/src/cambada/compile/core.clj
@@ -1,0 +1,43 @@
+(ns cambada.compile.core
+  (:refer-clojure :exclude [compile])
+  (:require [cambada.cli :as cli])
+  (:import [java.nio.file Path Paths Files]
+           [java.nio.file.attribute FileAttribute]
+           [java.io File]
+           [java.net URL URI URLClassLoader]))
+
+(defn- do-compile
+  ([namespaces]
+   (do-compile namespaces nil))
+  ([namespaces {:keys [compile-path compiler-options]}]
+   (let [namespaces (if (coll? namespaces)
+                      namespaces
+                      [namespaces])
+         compile-path (or compile-path "target/classes")
+         compile-path (if (string? compile-path)
+                        (Paths/get compile-path (make-array String 0))
+                        compile-path)]
+     (Files/createDirectories compile-path (make-array FileAttribute 0))
+     (binding [*compile-path* (str compile-path)
+               *compiler-options* (or compiler-options *compiler-options*)]
+       (doseq [namespace namespaces]
+         (cli/info "  Compiling" namespace)
+         (clojure.core/compile namespace))))))
+
+(defn classpath->paths [classpath]
+  (when classpath
+    (for [path (-> classpath
+                   clojure.string/trim
+                   (.split File/pathSeparator))]
+      (Paths/get path (make-array String 0)))))
+
+(defn paths->urls [paths]
+  (->> paths
+       (map #(.toUri ^Path %))
+       (map #(.toURL ^URI %))))
+
+(defn -main [namespaces options]
+  (let [namespaces (read-string namespaces)
+        options (read-string options)]
+    (do-compile namespaces options)
+    (clojure.core/shutdown-agents)))

--- a/src/cambada/jar.clj
+++ b/src/cambada/jar.clj
@@ -228,8 +228,9 @@
           pom (with-open [rdr (io/reader pom-file)]
                 (-> rdr
                     parse-xml
-                    (replace-header task)))]
-      (spit pom-file (xml/indent-str pom)))
+                    (replace-header task)
+                    xml/indent-str))]
+      (spit pom-file pom))
     (catch Throwable e
       (clojure.pprint/pprint e))))
 

--- a/src/cambada/jar.clj
+++ b/src/cambada/jar.clj
@@ -221,14 +221,17 @@
 
 (defn ^:private sync-pom
   [{:keys [deps-map] :as task}]
-  (cli/info "Updating pom.xml") 
-  (gen.pom/sync-pom deps-map (io/file ".")) 
-  (let [pom-file (io/file "." "pom.xml")
-        pom (with-open [rdr (io/reader pom-file)]
-              (-> rdr
-                  parse-xml
-                  (replace-header task)))]
-    (spit pom-file (xml/indent-str pom))))
+  (cli/info "Updating pom.xml")
+  (gen.pom/sync-pom deps-map (io/file "."))
+  (try
+    (let [pom-file (io/file "." "pom.xml")
+          pom (with-open [rdr (io/reader pom-file)]
+                (-> rdr
+                    parse-xml
+                    (replace-header task)))]
+      (spit pom-file (xml/indent-str pom)))
+    (catch Throwable e
+      (clojure.pprint/pprint e))))
 
 (defn apply! [{:keys [deps-map] :as task}]
   (compile/apply! task)

--- a/src/cambada/uberjar.clj
+++ b/src/cambada/uberjar.clj
@@ -68,7 +68,7 @@
   (into (map-vals {}
                   (comp make-merger eval))
         (map #(vector % skip-merger)
-             [])))
+             (:uberjar-exclusions project))))
 
 (defn ^:private select-merger [mergers filename]
   (or (->> mergers (filter #(merger-match? % filename)) first second)
@@ -138,7 +138,8 @@
       (write-components task jars out))))
 
 (defn -main [& args]
-  (let [{:keys [help] :as task} (cli/args->task args cli-options)]
+  (let [{:keys [help] :as task} (-> (cli/args->task args cli-options)
+                                    (assoc :uberjar-exclusions [#"(?i)^META-INF/[^/]*\.(SF|RSA|DSA)$"]))]
     (cli/runner
      {:help? help
       :task task


### PR DESCRIPTION
This commit should fix #16 

Dependencies from cambada itself are loaded into classloader and if some project
is relying on one of that dependency (eg. clojure.data.xml) compiled class will
not be presented in compiled target directory.

Implementation for that is taken from
[badigeon](https://github.com/EwenG/badigeon). Another build tool for clojure
cli.