### PR TITLE
Update to Clojure 1.10.0 and tools.deps 0.6.480

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,9 @@
 {:paths ["src"]
  :deps
- {org.clojure/clojure          {:mvn/version "1.9.0"}
+ {org.clojure/clojure          {:mvn/version "1.10.0"}
   org.clojure/data.xml         {:mvn/version "0.2.0-alpha5"}
   org.clojure/tools.cli        {:mvn/version "0.3.7"}
-  org.clojure/tools.deps.alpha {:mvn/version "0.5.435"}
+  org.clojure/tools.deps.alpha {:mvn/version "0.6.480"}
   org.clojure/tools.namespace  {:mvn/version "0.2.11"}}
 
  :aliases


### PR DESCRIPTION
This brings in the tools.deps fix for Maven classifiers among other fixes.