### PR TITLE
Fix/#21

### DIFF
--- a/src/cambada/jar.clj
+++ b/src/cambada/jar.clj
@@ -189,9 +189,12 @@
 
 (defn- parse-xml
   [^Reader rdr]
-  (let [roots (tree/seq-tree event/event-element event/event-exit? event/event-node
-                             (xml/event-seq rdr {:include-node? #{:element :characters :comment}}))]
-    (first (filter #(instance? Element %) (first roots)))))
+  (let [events (xml/event-seq rdr {:include-node? #{:element :characters :comment}})
+        roots  (tree/seq-tree event/event-element event/event-exit? event/event-node events)]
+    (->> roots
+         first
+         (filter #(instance? Element %))
+         first)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cambada/jar.clj
+++ b/src/cambada/jar.clj
@@ -193,7 +193,7 @@
         roots  (tree/seq-tree event/event-element event/event-exit? event/event-node events)]
     (->> roots
          first
-         (filter #(instance? Element %))
+         (filterv #(instance? Element %))
          first)))
 
 


### PR DESCRIPTION
fix #21: That was a floating bug. When pom-file is quite big (~8KB), it is closed by with-open, while not all elements consumed from lazy tree-seq. So we use filterv instead of filter to force lazy-seq realization